### PR TITLE
Generate index file dynamically

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -10,7 +10,7 @@ TARGET_BRANCH="gh-pages"
 
 function doCompile {
     echo "Compiling..."
-    npm run build
+    npm run build:prod
 }
 # Pull requests and commits to other branches shouldn't try to deploy, just build to verify
 if [ "$TRAVIS_PULL_REQUEST" != "false" -o "$TRAVIS_BRANCH" != "$SOURCE_BRANCH" ]; then

--- a/html-template/example.html
+++ b/html-template/example.html
@@ -26,10 +26,10 @@
 <div id="<%= htmlWebpackPlugin.options.appMountIds[index]%>"></div>
 <% } } if (htmlWebpackPlugin.options.window) { %>
 <script><% for (var varName in htmlWebpackPlugin.options.window) { %>
-    window['<%=varName%>'] = <%= JSON.stringify(htmlWebpackPlugin.options.window[varName]) %>;<% } %>
+        window['<%=varName%>'] = <%= JSON.stringify(htmlWebpackPlugin.options.window[varName]) %>;<% } %>
 </script>
-<% } for (var example in htmlWebpackPlugin.options.examples) {  %>
-<a href="/<%= htmlWebpackPlugin.options.relativeURL %><%= htmlWebpackPlugin.options.examples[example].split('.')[0] %>.html" class="" title="<%= htmlWebpackPlugin.options.examples[example].split('.')[0] %>.html"><%= htmlWebpackPlugin.options.examples[example].split('.')[0] %>.html</br></a>
+<% } for (var lib in htmlWebpackPlugin.options.libs) {  %>
+<script src="<%= htmlWebpackPlugin.options.libs[lib] %>"></script>
 <% } for (var chunk in htmlWebpackPlugin.files.chunks) { if (htmlWebpackPlugin.options.title == chunk || htmlWebpackPlugin.options.commonChunk == chunk) { %>
 <script src="<%= htmlWebpackPlugin.files.chunks[chunk].entry %>"></script>
 <% } } if (htmlWebpackPlugin.options.devServer) { %>
@@ -37,8 +37,8 @@
 <% } if (htmlWebpackPlugin.options.googleAnalytics) { %>
 <script>
     (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-            (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-        m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+                (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+            m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
     })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
 

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "prebuild:dev": "npm run clean:bin",
     "build:dev": "webpack --config webpack.config.js --progress --profile --colors --display-error-details --display-cached",
     "prebuild:prod": "npm run clean:bin",
-    "build:prod": "webpack --config webpack.config.js  --progress --profile --colors --display-error-details --display-cached --bail",
+    "build:prod": "relativeURL=awayjs-examples/ webpack --config webpack.config.js  --progress --profile --colors --display-error-details --display-cached --bail",
     "server": "npm run server:dev",
     "server:dev": "webpack-dev-server --config webpack.config.js --inline --progress --profile --watch --content-base bin",
     "server:dev:hmr": "npm run server:dev -- --hot",

--- a/src/Basic_Shading.ts
+++ b/src/Basic_Shading.ts
@@ -133,7 +133,7 @@ class Basic_Shading
 
 		this._light2 = new DirectionalLight();
 		this._light2.direction = new Vector3D(0, -1, 0);
-		this._light2.color = 0xFF0000;
+		this._light2.color = 0x00FFFF;
 		this._light2.ambient = 0.1;
 		this._light2.diffuse = 0.7;
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -37,17 +37,28 @@ var plugins = [
     // })
 ];
 
+// Generate individual html files for each example.
 for (var i = 0; i < examples.length; i++) {
     var name = examples[i].split('.')[0];
     plugins.push(new HtmlWebPackPlugin({
         title: name,
-        template: 'html-template/index.html',
+        template: 'html-template/example.html',
         filename: name + '.html',
         inject: false,
         commonChunk: 'awayjs-full'
         // libs: ['libs/awayjs-full.js']
     }));
 }
+
+// Generate a listing html that links to all examples.
+plugins.push(new HtmlWebPackPlugin({
+    title: 'awayjs-examples',
+    template: 'html-template/index.html',
+    filename: 'index.html',
+    examples: examples,
+    relativeURL: process.env.relativeURL || '',
+    inject: false
+}));
 
 module.exports = {
 


### PR DESCRIPTION
Two html templates are used. The old index.html becomes example.html and the new index.html simply contains a list of links to the examples. If a new example is added, webpack generates the example's html page (as it use to) but now also adds it to the index.html listing.

Note that there is absolutely no design in this index page, we might want to pretty-fy it =P